### PR TITLE
Bugfix/kzz scaletypes

### DIFF
--- a/IDLCodes/fitmodelgrid_final.pro
+++ b/IDLCodes/fitmodelgrid_final.pro
@@ -374,26 +374,25 @@ pro fitmodelgrid_final, configfilepathandname, MAKEFIGURES = makefigures
   printf, lun, '#'
   CASE scaletype OF
     'None': begin
-      printf, lun, '# Filename                                  T_eff             log(g)         f_sed             chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)'
+      printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)'
     end
     'Scale': begin
-      printf, lun, '# Filename                                  T_eff             log(g)         f_sed             chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       scale'
+      printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       scale'
     end
     'ScaleAndOffset': begin
-      printf, lun, '# Filename                                  T_eff             log(g)         f_sed             chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       scale        offset'
+      printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       scale        offset'
     end
     'Linear': begin
-      printf, lun, '# Filename                                  T_eff             log(g)         f_sed             chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       slope        intercept'
+      printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       slope        intercept'
     end
     'LinearAndOffset': begin
-      printf, lun, '# Filename                                  T_eff             log(g)         f_sed             chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       slope        intercept       offset'
+      printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       slope        intercept       offset'
     end
     'Quadratic': begin
-        ;printf, lun, '# Filename                                  T_eff             log(g)         f_sed             chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       a        b       c'
       printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       a        b       c'
     end
     'QuadraticAndOffset': begin
-        printf, lun, '# Filename                                  T_eff             log(g)         f_sed             chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       a        b       c       offset'
+        printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       a        b       c       offset'
     end
   ENDCASE
   Free_lun, lun
@@ -418,7 +417,7 @@ pro fitmodelgrid_final, configfilepathandname, MAKEFIGURES = makefigures
 
     ;;;;;;;;;
     ; GET THIS MODEL'S PARAMETERS from it's filename
-    modelparams = getmodelparameters_final(modeltype, modelnames[m]) ; modelparams = [temperature, g, fsed]
+    modelparams = getmodelparameters_final(modeltype, modelnames[m]) ; modelparams = [temperature, g, fsed, kzz]
 
     ;;;;;;;;;
     ; READ IN THE MODEL
@@ -507,26 +506,26 @@ pro fitmodelgrid_final, configfilepathandname, MAKEFIGURES = makefigures
         
         CASE scaletype OF
           'None': begin
-            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', $
+            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', trim(modelparams[3]), '    ', $
               chisquarevalue, dof, reducedchisquarevalue, vsinis[v], '  ', shifts[s]
           end
           'Scale': begin
-            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', $
+            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', trim(modelparams[3]), '    ', $
               chisquarevalue, dof, reducedchisquarevalue, vsinis[v], '  ', shifts[s], ' ', $
               constants[0]
           end
           'ScaleAndOffset': begin
-            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', $
+            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', trim(modelparams[3]), '    ', $
               chisquarevalue, dof, reducedchisquarevalue, vsinis[v], '  ', shifts[s], ' ', $
               constants[0], constants[1]
           end
           'Linear': begin
-            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', $
+            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', trim(modelparams[3]), '    ', $
               chisquarevalue, dof, reducedchisquarevalue, vsinis[v], '  ', shifts[s], ' ', $
               constants[0], constants[1]
           end
           'LinearAndOffset': begin
-            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', $
+            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', trim(modelparams[3]), '    ', $
               chisquarevalue, dof, reducedchisquarevalue, vsinis[v], '  ', shifts[s], ' ', $
               constants[0], constants[1], constants[2]
           end 
@@ -534,10 +533,10 @@ pro fitmodelgrid_final, configfilepathandname, MAKEFIGURES = makefigures
             printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', trim(modelparams[3]), '    ', $
               chisquarevalue, dof, reducedchisquarevalue, vsinis[v], '  ', shifts[s], ' ', $
               constants[0], constants[1], constants[2]
-              ;printf, lun, '# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       a        b       c'
+              ; # Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       a        b       c
           end
           'QuadraticAndOffset': begin
-            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', $
+            printf, lun, modelnames[m], '   ', trim(modelparams[0]), '    ', trim(modelparams[1]), '    ', trim(modelparams[2]), '    ', trim(modelparams[3]), '    ', $
               chisquarevalue, dof, reducedchisquarevalue, vsinis[v], '  ', shifts[s], ' ', $
               constants[0], constants[1], constants[2], constants[3]
           end         

--- a/IDLCodes/getmodelparameters_final.pro
+++ b/IDLCodes/getmodelparameters_final.pro
@@ -146,6 +146,8 @@ function getmodelparameters_final, modeltype, modelfilename
 
       ; no f_sed value in the Alt-A models. Set to the placeholder value 0
       fsed = 0
+      ; no kzz value. Set to the placeholder value 0
+      kzz = 0
     end
 
     'BTSETTL-CIFIST2011': begin

--- a/IDLCodes/getmodelparameters_final.pro
+++ b/IDLCodes/getmodelparameters_final.pro
@@ -68,7 +68,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'f',/EXTRACT)
       g = split[0]
       g = uint(g)
-      g = alog10(x * 100.) ; in log10(cm/s/s)
+      g = alog10(g * 100.) ; in log10(cm/s/s)
 
 
       ; f_sed
@@ -97,7 +97,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'f',/EXTRACT)
       g = split[0]
       g = uint(g)
-      g = alog10(x * 100.) ; in log10(cm/s/s)
+      g = alog10(g * 100.) ; in log10(cm/s/s)
 
       ; f_sed
       split = STRSPLIT(split[1],'_',/EXTRACT)
@@ -124,7 +124,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
-      g = alog10(x * 100.) ; in log10(cm/s/s)
+      g = alog10(g * 100.) ; in log10(cm/s/s)
 
       ; no f_sed value in the Sonora models. Set to the placeholder value of 0
       fsed = 0
@@ -148,7 +148,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
-      g = alog10(x * 100.) ; in log10(cm/s/s)
+      g = alog10(g * 100.) ; in log10(cm/s/s)
 
       ; no f_sed value in the Alt-A models. Set to the placeholder value 0
       fsed = 0
@@ -206,7 +206,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
-      g = alog10(x * 100.) ; in log10(cm/s/s)
+      g = alog10(g * 100.) ; in log10(cm/s/s)
 
       ; fsed
       split = STRSPLIT(modelfilename,'f',/EXTRACT)
@@ -243,7 +243,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
-      g = alog10(x * 100.) ; in log10(cm/s/s)
+      g = alog10(g * 100.) ; in log10(cm/s/s)
 
       ; fsed
       split = STRSPLIT(modelfilename,'f',/EXTRACT)

--- a/IDLCodes/getmodelparameters_final.pro
+++ b/IDLCodes/getmodelparameters_final.pro
@@ -22,9 +22,10 @@
 ; RETURNS:
 ;    values - a three-component vector of [temperature, logg, fsed].
 ;          Where temperature is the effective temperature of the model 
-;          in Kelvin, logg is the log(g) of the model, where g is in 
-;          the units below. fsed is the sedimentation efficiency, and
-;          defaults to fsed = 0 if the model family does not include fsed.
+;          in Kelvin, logg is the log(g) of the model, where g is in units
+;          of cm/s/s. The unit shown in each model family is below. fsed is
+;          the sedimentation efficiency, and defaults to fsed = 0 if the 
+;          model family does not include fsed.
 ;          
 ;          g units: MORLEY: m/s/s
 ;                   SAUMON: m/s/s
@@ -67,6 +68,8 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'f',/EXTRACT)
       g = split[0]
       g = uint(g)
+      g = alog10(x * 100.) ; in log10(cm/s/s)
+
 
       ; f_sed
       split = STRSPLIT(split[1],'_',/EXTRACT)
@@ -94,6 +97,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'f',/EXTRACT)
       g = split[0]
       g = uint(g)
+      g = alog10(x * 100.) ; in log10(cm/s/s)
 
       ; f_sed
       split = STRSPLIT(split[1],'_',/EXTRACT)
@@ -120,6 +124,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
+      g = alog10(x * 100.) ; in log10(cm/s/s)
 
       ; no f_sed value in the Sonora models. Set to the placeholder value of 0
       fsed = 0
@@ -143,6 +148,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
+      g = alog10(x * 100.) ; in log10(cm/s/s)
 
       ; no f_sed value in the Alt-A models. Set to the placeholder value 0
       fsed = 0
@@ -174,7 +180,7 @@ function getmodelparameters_final, modeltype, modelfilename
       ; log(g) where g is in units of cm/s/s
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
-      g = float(g) ; this is log(g)
+      g = float(g) ; this is already in log(g [cm/s/s])
 
       ; no f_sed value in the Allard models. Set to the placeholder value 0
       fsed = 0
@@ -200,6 +206,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
+      g = alog10(x * 100.) ; in log10(cm/s/s)
 
       ; fsed
       split = STRSPLIT(modelfilename,'f',/EXTRACT)
@@ -236,6 +243,7 @@ function getmodelparameters_final, modeltype, modelfilename
       split = STRSPLIT(split[1],'n',/EXTRACT)
       g = split[0]
       g = uint(g)
+      g = alog10(x * 100.) ; in log10(cm/s/s)
 
       ; fsed
       split = STRSPLIT(modelfilename,'f',/EXTRACT)

--- a/IDLCodes/savebestmodel_final.pro
+++ b/IDLCodes/savebestmodel_final.pro
@@ -82,8 +82,8 @@ pro savebestmodel_final, configfilepathandname
   print, 'savebestmodel_final.pro: Reading ' + outfilepath + inputfilename
   ;fmt = 'A,I,F,I,D,D,D,D,D' ; format of filename
   ;readcol, outfilepath + inputfilename, FORMAT = fmt, bestmodelname, bestT, bestlogg, bestf, bestchi, bestdof, bestredchi, bestvsini, bestrvshift, /SILENT, COMMENT='#' ; Read in the data
-  fmt = 'A,I,F,I,I,D,D,D,D,D,D,D,D' ; format of filename
-  readcol, outfilepath + inputfilename, FORMAT = fmt, bestmodelname, bestT, bestlogg, bestf, bestk, bestchi, bestdof, bestredchi, bestvsini, bestrvshift, bestqa, bestqb, bestqc, /SILENT, COMMENT='#' ; Read in the data
+  fmt = 'A,I,F,I,I,D,D,D,D,D' ; format of filename
+  readcol, outfilepath + inputfilename, FORMAT = fmt, bestmodelname, bestT, bestlogg, bestf, bestk, bestchi, bestdof, bestredchi, bestvsini, bestrvshift, /SILENT, COMMENT='#' ; Read in the data
   ;# Filename                                  T_eff             log(g)         f_sed          kzz        chisquare       d.o.f.             reduchisquare    vsini(km/s)     rv(km/s)       a        b       c
   bestindex = where(bestchi eq min(bestchi))
 


### PR DESCRIPTION
Solved the problem that `kzz` (with 0 as placeholder) was not written out and cannot be plotted when using models other than `SONORA-BOBCAT`.

In addition, the unit of log _g_ recorded was unified to log(_g_ [cm/s/s]).