### PR TITLE
Figure without xwindow

### DIFF
--- a/IDLCodes/savebestmodel_final.pro
+++ b/IDLCodes/savebestmodel_final.pro
@@ -91,7 +91,7 @@ pro savebestmodel_final, configfilepathandname
   print, size(bestindex)
   print, n_elements(bestindex)
   IF n_elements(bestindex) gt 1 THEN BEGIN
-    print, 'Multiple bestindexes are reduced to one as a temporary measure.'
+    print, '!WARNING!:  Multiple bestindexes are reduced to one as a temporary measure.'
     bestindex = bestindex[0]
   endif
   
@@ -327,9 +327,12 @@ pro savebestmodel_final, configfilepathandname
     /current, layout=[1,3,3], $
     /buffer)
   outputfigurefilename = outfilepath + 'figures/' + outfilename + '_bestfit_figure'
-  p5.save, outputfigurefilename + '.png'
+
+  ; You can choose the file type for the output figures.
+  ; p5.save, outputfigurefilename + '.png'
   p5.save, outputfigurefilename + '.pdf'
-  ;p5.save, outputfigurefilename + '.eps'
+  ; p5.save, outputfigurefilename + '.eps'
+  
   p5.close
 
   ;;;;;;;

--- a/IDLCodes/savebestmodel_final.pro
+++ b/IDLCodes/savebestmodel_final.pro
@@ -332,23 +332,6 @@ pro savebestmodel_final, configfilepathandname
   ;p5.save, outputfigurefilename + '.eps'
   p5.close
 
-  ; tmp notes by Tako... (Removed in the fugure)
-  ; The NAME field of the !D system variable contains the name of the
-  ; current plotting device.
-  ;;;     mydevice = !D.NAME
-  ; Set plotting to PostScript:
-  ;;;     SET_PLOT, 'Z'
-  ; Use DEVICE to set some PostScript device options:
-  ;DEVICE, FILENAME=outputfigurefilename+'.png', /LANDSCAPE
-  ;;;     DEVICE, set_resolution=[640,680]
-  ; Make a simple plot to the PostScript file:
-  ;;;     PLOT, FINDGEN(10)
-  ;;;     write_png, 'test_filename.png', tvrd()
-  ; Close the PostScript file:
-  ;;;     DEVICE, /CLOSE
-  ; Return plotting to the original device:
-  ;;;     SET_PLOT, mydevice
-
   ;;;;;;;
   ; SAVE SPECTRUM WITH MODEL AS A TEXT FILE
   openw,lun, outfilepath + 'figures/' + outfilename + '_bestfit_figuredata.dat', /get_lun, WIDTH=250; , /APPEND

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ If you make use of these codes, please cite the following two publications:
 The IDL Codes required for this tool are all contained in the IDLCodes/ folder. You will 
 also need the IDL Astronomy User's Library which is available at this website:
 https://idlastro.gsfc.nasa.gov/
+(Especially, these two libraries are required:  
+    - /usr/local/harris/idl88/external/astron  
+    - /usr/local/harris/idl88/external/coyote )  
 
 You should place all of these IDL codes in your IDLWorkspace directory, and ensure they are
 added to your IDL paths.


### PR DESCRIPTION
Figure output is now possible without Xwindow.
This is useful when working on a remote server with only a command line login (For example, when working through the entire process from fitting to plot creation in multiple tmux sessions!).
The default format for saving output figures is pdf, but this can be changed in “savebestmodel_final.pro”.