### PR TITLE
Instrumental broadening

### DIFF
--- a/IDLCodes/broadenforip.pro
+++ b/IDLCodes/broadenforip.pro
@@ -1,18 +1,21 @@
 ; NAME;
-; broadenforip.pro
+;   broadenforip.pro
 ;
 ; AUTHOR:
-; Hiroyuki Tako Ishikawa (contact: hishikaw@uwo.ca)
+;   Hiroyuki Tako Ishikawa (contact: hishikaw@uwo.ca)
 ;
 ; PURPOSE:
-; To broaden spectra with IGRINS's instrumental profile
+;   To broaden spectra with instrumental profiles (IP)
 ;
 ; INPUT PARAMETERS:
-;
+;   wavelength (µm)
+;   flux
+;   
 ; RETURNS:
+;   wavelengths convolved with IP
 ;
 ; CALLING SEQUENCE:
-;
+;   flux_broadened = broadenforip(wavelength, flux)
 ;
 
 function inverted_gaussian_with_trend, x, amp, cen, wid, offset, slope
@@ -32,7 +35,7 @@ function convolve_spectrum, w_all, f_all, lsf_sigma_in_micron, length_lsf_to_con
 
   x_lsf_full = findgen(length_lsf_to_convolve) / (length_lsf_to_convolve - 1)
   lsf_full = inverted_gaussian_with_trend(x_lsf_full, 1, 0.5, lsf_sigma, 0, 0)
-  lsf_full = lsf_full / total(lsf_full) ; 正規化
+  lsf_full = lsf_full / total(lsf_full)
   f_all_convolved = convol(double(f_all), double(lsf_full), /edge_truncate)
   return, f_all_convolved
 end
@@ -46,45 +49,3 @@ function broadenforip, wavelength, flux, wav_micron=wav_micron
 
   return, convolve_spectrum(wavelength, flux, sigma_ip)
 end
-
-; test
-; function testrun
-;   compile_opt idl2
-
-;   ; データの読み込み
-;   file_path = '/Users/chonmac/Downloads/test_spec_broadenforip.dat'
-;   readcol, file_path, wavelength, flux, format = 'D,D'
-
-;   ; broadenforipを使ってブロードニング
-;   flux_broadened = broadenforip(wavelength, flux)
-
-;   ; グラフィックスデバイスを24ビットカラーモードに設定
-;   device, decomposed = 1, true_color = 24
-
-;   ; 結果のプロット（背景を白に設定）
-;   PLOT, wavelength, flux, $
-;     xtitle = 'Wavelength', $
-;     ytitle = 'Flux', $
-;     title = 'Original vs Broadened Spectrum', $
-;     /nodata, $
-;     background = 'ffffff'x, $ ; 背景色を白に設定 (16進数)
-;     color = '000000'x ; テキストと軸の色を黒に設定 (16進数)
-
-;   ; オリジナルのスペクトルをプロット
-;   oplot, wavelength, flux, color = '000000'x ; 黒色 (16進数)
-
-;   ; ブロードニングされたスペクトルをプロット
-;   oplot, wavelength, flux_broadened, color = 'ff5f7f'x ; 赤色 (16進数)
-
-;   ; legendの追加
-;   AL_LEGEND, ['Original', 'Broadened'], $
-;     linestyle = [0, 0], $
-;     colors = ['000000'x, 'ff5f7f'x], $ ; 黒と赤 (16進数)
-;     position = [0.1, 0.9], $
-;     /normal, $
-;     charsize = 1.0
-
-;   ; plot, wavelength, flux, xtitle = 'Wavelength', ytitle = 'Flux', title = 'Original vs Broadened Spectrum'
-;   ; oplot, wavelength, flux_broadened, color = 255 ; 赤色のインデックス
-;   ; cgLegend, titles = ['Original', 'Broadened'], linestyle = [0, 0], colors = [0, 255], /addcmd
-; end

--- a/IDLCodes/broadenforip.pro
+++ b/IDLCodes/broadenforip.pro
@@ -1,0 +1,90 @@
+; NAME;
+; broadenforip.pro
+;
+; AUTHOR:
+; Hiroyuki Tako Ishikawa (contact: hishikaw@uwo.ca)
+;
+; PURPOSE:
+; To broaden spectra with IGRINS's instrumental profile
+;
+; INPUT PARAMETERS:
+;
+; RETURNS:
+;
+; CALLING SEQUENCE:
+;
+;
+
+function inverted_gaussian_with_trend, x, amp, cen, wid, offset, slope
+  compile_opt idl2
+  return, amp * exp(-(x - cen) ^ 2 / (2 * wid ^ 2)) + offset + slope * x
+end
+
+
+function convolve_spectrum, w_all, f_all, lsf_sigma_in_micron, length_lsf_to_convolve
+  compile_opt idl2
+  if n_elements(length_lsf_to_convolve) eq 0 then length_lsf_to_convolve = 100
+
+  ; lsf_sigmaの計算
+  lambda_per_pixel_model = (max(w_all) - min(w_all)) / (n_elements(w_all) - 1)
+  N_pixel_model = length_lsf_to_convolve - 1
+  lsf_sigma = lsf_sigma_in_micron / (lambda_per_pixel_model * N_pixel_model)
+
+  x_lsf_full = findgen(length_lsf_to_convolve) / (length_lsf_to_convolve - 1)
+  lsf_full = inverted_gaussian_with_trend(x_lsf_full, 1, 0.5, lsf_sigma, 0, 0)
+  lsf_full = lsf_full / total(lsf_full) ; 正規化
+  f_all_convolved = convol(double(f_all), double(lsf_full), /edge_truncate)
+  return, f_all_convolved
+end
+
+
+function broadenforip, wavelength, flux, wav_micron=wav_micron
+  compile_opt idl2
+
+  if n_elements(wav_micron) eq 0 then wav_micron = mean(wavelength)  
+  sigma_ip = get_sigma_ip(wav_micron)
+
+  return, convolve_spectrum(wavelength, flux, sigma_ip)
+end
+
+; test
+; function testrun
+;   compile_opt idl2
+
+;   ; データの読み込み
+;   file_path = '/Users/chonmac/Downloads/test_spec_broadenforip.dat'
+;   readcol, file_path, wavelength, flux, format = 'D,D'
+
+;   ; broadenforipを使ってブロードニング
+;   flux_broadened = broadenforip(wavelength, flux)
+
+;   ; グラフィックスデバイスを24ビットカラーモードに設定
+;   device, decomposed = 1, true_color = 24
+
+;   ; 結果のプロット（背景を白に設定）
+;   PLOT, wavelength, flux, $
+;     xtitle = 'Wavelength', $
+;     ytitle = 'Flux', $
+;     title = 'Original vs Broadened Spectrum', $
+;     /nodata, $
+;     background = 'ffffff'x, $ ; 背景色を白に設定 (16進数)
+;     color = '000000'x ; テキストと軸の色を黒に設定 (16進数)
+
+;   ; オリジナルのスペクトルをプロット
+;   oplot, wavelength, flux, color = '000000'x ; 黒色 (16進数)
+
+;   ; ブロードニングされたスペクトルをプロット
+;   oplot, wavelength, flux_broadened, color = 'ff5f7f'x ; 赤色 (16進数)
+
+;   ; legendの追加
+;   AL_LEGEND, ['Original', 'Broadened'], $
+;     linestyle = [0, 0], $
+;     colors = ['000000'x, 'ff5f7f'x], $ ; 黒と赤 (16進数)
+;     position = [0.1, 0.9], $
+;     /normal, $
+;     charsize = 1.0
+
+;   ; plot, wavelength, flux, xtitle = 'Wavelength', ytitle = 'Flux', title = 'Original vs Broadened Spectrum'
+;   ; oplot, wavelength, flux_broadened, color = 255 ; 赤色のインデックス
+;   ; cgLegend, titles = ['Original', 'Broadened'], linestyle = [0, 0], colors = [0, 255], /addcmd
+; end

--- a/IDLCodes/broadenforvsini_final.pro
+++ b/IDLCodes/broadenforvsini_final.pro
@@ -1,98 +1,98 @@
 ; NAME:
-;     BROADENFORVSINI_FINAL
+; BROADENFORVSINI_FINAL
 ;
 ; AUTHOR:
-;      Megan E. Tannock (contact: mtannock@uwo.ca)
+; Megan E. Tannock (contact: mtannock@uwo.ca)
 ;
 ; PURPOSE:
 ;
-;     For use with FITMODELGRID_FINAL.PRO
+; For use with FITMODELGRID_FINAL.PRO
 ;
-;     Broadens the input model flux by the input velocity by convolving
-;     the broadening profile of Gray (1992) (generated with lsf_rotate.pro 
-;     from the Astronomy User's Library: https://idlastro.gsfc.nasa.gov/ftp/pro/astro/lsf_rotate.pro) 
-;     with your model flux.
-;     
-;     If your model's resolution changes a lot across the wavelengths
-;     of interest, you may end up overbroadening or underbroadening
-;     the ends of the spectrum by using the same kernel across the whole
-;     spectrum. A convolution, by definition, has a fixed kernel. Instead 
-;     of generating a linear transform to deal with the changing
-;     resolution, we take the simple approach of splitting the spectrum
-;     in to N sections and broadening each section with its own kernel,
-;     then stitching the resulting spectrum back together. If you do not
-;     want to do this, set numkernels=1.
-;     
-;     If you make use to this code, please cite the following two publications:
-;       Tannock M. E., et al., 2021, AJ, 161, 224      https://ui.adsabs.harvard.edu/abs/2022MNRAS.514.3160T/abstract
-;       Tannock M. E., et al., 2022, MNRAS, 514, 3160  https://ui.adsabs.harvard.edu/abs/2021AJ....161..224T/abstract
+; Broadens the input model flux by the input velocity by convolving
+; the broadening profile of Gray (1992) (generated with lsf_rotate.pro
+; from the Astronomy User's Library: https://idlastro.gsfc.nasa.gov/ftp/pro/astro/lsf_rotate.pro)
+; with your model flux.
+;
+; If your model's resolution changes a lot across the wavelengths
+; of interest, you may end up overbroadening or underbroadening
+; the ends of the spectrum by using the same kernel across the whole
+; spectrum. A convolution, by definition, has a fixed kernel. Instead
+; of generating a linear transform to deal with the changing
+; resolution, we take the simple approach of splitting the spectrum
+; in to N sections and broadening each section with its own kernel,
+; then stitching the resulting spectrum back together. If you do not
+; want to do this, set numkernels=1.
+;
+; If you make use to this code, please cite the following two publications:
+; Tannock M. E., et al., 2021, AJ, 161, 224      https://ui.adsabs.harvard.edu/abs/2022MNRAS.514.3160T/abstract
+; Tannock M. E., et al., 2022, MNRAS, 514, 3160  https://ui.adsabs.harvard.edu/abs/2021AJ....161..224T/abstract
 ;
 ; INPUT PARAMETERS:
-;    modellam - your model's wavelength scale in microns, an array of floats
-;    modelflux - your model's flux values, an array of floats
-;    vsini - the velocity to broaden to, a float
-;    numkernels - the number of sections to divide this spectrum in to, a float.
-;         Each section gets its own kernel for broadening. Use this if your 
-;         model changes resolution a lot from one end to the other. If you don't
-;         want to do this, use 1.
-;    limbdarkeningcoefficient - Numeric scalar giving the limb-darkening
-;          coefficient. Use 0.6 as the default value. This is used in
-;          lsf_rotate.pro, see documentation for details:
-;          https://idlastro.gsfc.nasa.gov/ftp/pro/astro/lsf_rotate.pro
+; modellam - your model's wavelength scale in microns, an array of floats
+; modelflux - your model's flux values, an array of floats
+; vsini - the velocity to broaden to, a float
+; numkernels - the number of sections to divide this spectrum in to, a float.
+; Each section gets its own kernel for broadening. Use this if your
+; model changes resolution a lot from one end to the other. If you don't
+; want to do this, use 1.
+; limbdarkeningcoefficient - Numeric scalar giving the limb-darkening
+; coefficient. Use 0.6 as the default value. This is used in
+; lsf_rotate.pro, see documentation for details:
+; https://idlastro.gsfc.nasa.gov/ftp/pro/astro/lsf_rotate.pro
 ;
 ; RETURNS:
-;     modelflux_broadened_stitched - your broadened model flux
+; modelflux_broadened_stitched - your broadened model flux
 ;
 ; CALLING SEQUENCE:
-;     broadenedmodel = broadenforvsini_final(modellam, modelflux, 21.5, 10)
+; broadenedmodel = broadenforvsini_final(modellam, modelflux, 21.5, 10)
 ;
 
 function broadenforvsini_final, modellam_in, modelflux_in, vsini, numkernels, limbdarkeningcoefficient
+  compile_opt idl2
   c = 2.99792458d5 ; km/s - speed of light
-  
+
   if numkernels eq 1 then begin
-    
     centreindex = round(n_elements(modellam_in) / 2.) ; get the index for the element in the middle of the wavelength array
-    deltaV = ((modellam_in[centreindex] - modellam_in[centreindex-1])*c) / (modellam_in[centreindex]) ; numeric scalar giving the step increment (in km/s) in the output rotation kernel.
-    lsf = lsf_rotate(deltaV, vsini, EPSILON=limbdarkeningcoefficient) ; Generate line Spread Function kernel (LSF)
+    deltaV = ((modellam_in[centreindex] - modellam_in[centreindex - 1]) * c) / (modellam_in[centreindex]) ; numeric scalar giving the step increment (in km/s) in the output rotation kernel.
+    lsf = lsf_rotate(deltaV, vsini, epsilon = limbdarkeningcoefficient) ; Generate line Spread Function kernel (LSF)
+    lsf = lsf / total(lsf, 1)
     ; LSF_ROTATE.PRO is from the Astronomy User's Library: https://idlastro.gsfc.nasa.gov/ftp/pro/astro/lsf_rotate.pro
-    modelflux_broadened_stitched = CONVOL(modelflux_in, lsf) ; convolve spectrum with LSF kernel
-    
+    modelflux_broadened_stitched = convol(modelflux_in, lsf) ; convolve spectrum with LSF kernel
+
     ; do a rough normalization
     modelflux_broadened_stitched = modelflux_broadened_stitched / median(modelflux_broadened_stitched)
-    
   endif else begin
-    
     elements = n_elements(modellam_in)
-    modelflux_broadened = MAKE_ARRAY(elements,numkernels) * 0 ; make an array to fill in with the broadened spectra for each kernel
+    modelflux_broadened = make_array(elements, numkernels) * 0 ; make an array to fill in with the broadened spectra for each kernel
     width = uint(float(elements) / float(numkernels))
-    indices = uint(ARRGEN(width/2., elements-(width/2.), nstep = numkernels)) ; figure out your indices for the kernel, make sure they are integers
+    indices = uint(arrgen(width / 2., elements - (width / 2.), nstep = numkernels)) ; figure out your indices for the kernel, make sure they are integers
 
-    for nk=0, numkernels-1 do begin
-      deltaV = abs(((modellam_in[indices[nk]] - modellam_in[indices[nk]-1])*c) / (modellam_in[indices[nk]])) ; numeric scalar giving the step increment (in km/s) in the output rotation kernel.
-      lsf = lsf_rotate(deltaV,vsini, EPSILON=limbdarkeningcoefficient) ; Generate line Spread Function kernel (LSF)
+    for nk = 0, numkernels - 1 do begin
+      deltaV = abs(((modellam_in[indices[nk]] - modellam_in[indices[nk] - 1]) * c) / (modellam_in[indices[nk]])) ; numeric scalar giving the step increment (in km/s) in the output rotation kernel.
+      lsf = lsf_rotate(deltaV, vsini, epsilon = limbdarkeningcoefficient) ; Generate line Spread Function kernel (LSF)
+      lsf = lsf / total(lsf, 1)
       ; LSF_ROTATE.PRO is from the Astronomy User's Library: https://idlastro.gsfc.nasa.gov/ftp/pro/astro/lsf_rotate.pro
-      modelflux_broadened[*,nk] = CONVOL(modelflux_in, lsf, /edge_constant) ; convolve spectrum with LSF kernel
+      modelflux_broadened[*, nk] = convol(modelflux_in, lsf, /edge_constant) ; convolve spectrum with LSF kernel
 
       ; do a rough normalization:
-      modelflux_broadened[*,nk] = modelflux_broadened[*,nk] / median(modelflux_broadened[*,nk])
+      modelflux_broadened[*, nk] = modelflux_broadened[*, nk] / median(modelflux_broadened[*, nk])
     endfor
 
     ; Now stitch together our sections:
 
     ; Make an array to hold the franken-spectrum:
-    modelflux_broadened_stitched = modelflux_broadened[*,0] * 0
+    modelflux_broadened_stitched = modelflux_broadened[*, 0] * 0
 
-    for nk=0, numkernels-1 do begin
-      startval = (nk*width)
+    for nk = 0, numkernels - 1 do begin
+      startval = (nk * width)
       endval = startval + width - 1
-      modelflux_broadened_stitched[startval:endval] = modelflux_broadened[startval:endval,nk]
+      modelflux_broadened_stitched[startval : endval] = modelflux_broadened[startval : endval, nk]
     endfor
   endelse
 
   return, modelflux_broadened_stitched
-
 end
-;     If you make use to this code, please cite the following two publications:
-;       Tannock M. E., et al., 2021, AJ, 161, 224      https://ui.adsabs.harvard.edu/abs/2022MNRAS.514.3160T/abstract
-;       Tannock M. E., et al., 2022, MNRAS, 514, 3160  https://ui.adsabs.harvard.edu/abs/2021AJ....161..224T/abstract
+
+; If you make use to this code, please cite the following two publications:
+; Tannock M. E., et al., 2021, AJ, 161, 224      https://ui.adsabs.harvard.edu/abs/2022MNRAS.514.3160T/abstract
+; Tannock M. E., et al., 2022, MNRAS, 514, 3160  https://ui.adsabs.harvard.edu/abs/2021AJ....161..224T/abstract

--- a/IDLCodes/fitmodelgrid_final.pro
+++ b/IDLCodes/fitmodelgrid_final.pro
@@ -311,22 +311,6 @@ pro fitmodelgrid_final, configfilepathandname, makefigures = makefigures
     datavalues[*, 2] = datavalues[*, 2] * mask ; mask the uncertainty
   endelse
 
-  ; #test241120 by Tako begin
-
-  ;   ;;;;;;;
-  ; ; SAVE SPECTRUM WITH MODEL AS A TEXT FILE
-  ; openw,lun, outfilepath + 'test4/' + 'testspectrum.dat', /get_lun, WIDTH=250; , /APPEND
-  ; printf, lun, '# SPECTRUM - TEST on 2024/11/20.'
-  ; printf, lun, '#'
-  ; IF (masktellurics eq 1) THEN printf, lun, '# TELLURIC LINE MASK APPLIED, <35% TRANSMISSION (from PSG) AND OH EMISSION LINES (from IGRINS documentation)'
-  ; IF (masktellurics eq 0) THEN printf, lun, '# NO TELLURIC LINE MASK APPLIED'
-
-  ; printf, lun, '# wavelength (um),    data flux,      uncertainty' ;,     model flux'
-  ; FOR i = 0, n_elements( datavalues[*, 0])-1 DO printf, lun, datavalues[i, 0], datavalues[i, 1], datavalues[i, 2] ;, error_final[i], modelflux_final[i]
-  ; Free_lun, lun
-
-  ; #test241120 by Tako end
-
   ; ;;;;;;;;
   ; CHOP OUT THE REGION OF INTEREST IN BOTH THE DATA AND MODEL
 
@@ -350,24 +334,6 @@ pro fitmodelgrid_final, configfilepathandname, makefigures = makefigures
 
   dataflux_match = datavalues_chop[*, 1] / normvalue
   error_match = errorvalues_chop[*, 1] / normvalue
-
-  ; #test241120 by Tako begin
-
-  ;   ;;;;;;;
-  ; ; SAVE SPECTRUM WITH MODEL AS A TEXT FILE
-  ; openw,lun, outfilepath + 'test4/' + 'testspectrum_norm.dat', /get_lun, WIDTH=250; , /APPEND
-  ; printf, lun, '# SPECTRUM after chopping and normalized - TEST on 2024/11/20.'
-  ; printf, lun, '#'
-  ; IF (masktellurics eq 1) THEN printf, lun, '# TELLURIC LINE MASK APPLIED, <35% TRANSMISSION (from PSG) AND OH EMISSION LINES (from IGRINS documentation)'
-  ; IF (masktellurics eq 0) THEN printf, lun, '# NO TELLURIC LINE MASK APPLIED'
-
-  ; printf, lun, '# wavelength (um),    data flux,      uncertainty' ;,     model flux'
-  ; FOR i = 0, n_elements(datalam_match)-1 DO printf, lun, datalam_match[i], dataflux_match[i], error_match[i] ;, error_final[i], modelflux_final[i]
-  ; Free_lun, lun
-
-  ; print, "#test241120 by Tako"
-  ; stop
-  ; #test241120 by Tako end
 
   ; ;;;;;;;;;;;;;;;;;;;;;;;;;;
   ; divide out continuum if requested...

--- a/IDLCodes/get_sigma_ip.pro
+++ b/IDLCodes/get_sigma_ip.pro
@@ -1,0 +1,46 @@
+; NAME;
+; get_sigma_ip.pro
+;
+; AUTHOR:
+; Hiroyuki Tako Ishikawa (contact: hishikaw@uwo.ca)
+;
+; PURPOSE:
+; To obtain sigma (µm) of instrumental broadening profiles (IP) for IGRINS
+;
+; INPUT PARAMETERS:
+;    wav_micron: wavelengths (µm)
+;    
+; RETURNS:
+;    Gaussian sigma of the instrumental profile (IP) broadening (µm)
+;    Note that The current (Dec, 2024) default settings are optimized 
+;        for the April-June 2018 Gemini South/IGRINS IP. Users will 
+;        need to edit this file if they are using slow rotators' 
+;        spectra from other instruments. (Ideally, it will be 
+;        possible to adjust it from an external file, such as config 
+;        files, in the future)
+;
+; CALLING SEQUENCE:
+;    sigma_ip = get_sigma_ip(wav_micron)
+;
+
+function linear_func, x, a, b
+  compile_opt idl2
+  return, a * x + b
+end
+
+function get_sigma_ip, wav_micron
+  compile_opt idl2
+  ; wav_micron: wavelengths in the order centre (µm)
+
+  switching_point = 1.850
+  popt1 = [4.15512657e-05, -4.16661217e-05]
+  popt2 = [4.25428496e-05, -5.86983801e-05]
+  const_adjust_lowerlim_H = 0 ; 0.51e-5
+  const_adjust_lowerlim_K = 0 ; 0.72e-5
+
+  if wav_micron le switching_point then begin
+    return, linear_func(wav_micron, popt1[0], popt1[1]) - const_adjust_lowerlim_H
+  endif else begin
+    return, linear_func(wav_micron, popt2[0], popt2[1]) - const_adjust_lowerlim_K
+  endelse
+end

--- a/IDLCodes/savebestmodel_final.pro
+++ b/IDLCodes/savebestmodel_final.pro
@@ -263,8 +263,14 @@ pro savebestmodel_final, configfilepathandname
   ;;;;;;;;;
   ; BROADEN THE MODEL TO THE VSINI
   ; Broaden with rotation kernel of Gray (1992)
-  modelflux_broadened = broadenforvsini_final(modellam_match, modelflux_match, vsinis[0], nkernels, limbdarkeningcoefficient)
-  ;;;;;;;;;;;;;;;;;;;;;;;;;;; end of broadening part of code
+  modelflux_broadened_vsini = broadenforvsini_final(modellam_match, modelflux_match, vsinis[0], nkernels, limbdarkeningcoefficient)
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;; end of rotational broadening part of code
+
+
+  ; ;;;;;;;;
+  ; APPLY INSTRUMENTAL PROFILE (IP) BROADENING
+  modelflux_broadened_vsini_ip = broadenforip(modellam_match, modelflux_broadened_vsini)
+  ; ;;;;;;;;;;;;;;;;;;;;;;;;;; end of IP broadening part of code
 
 
   ;;;;;;;;;
@@ -279,7 +285,7 @@ pro savebestmodel_final, configfilepathandname
   ;;;;;;;;;
   ; MATCH THE RESOLUTION OF THE MODEL TO THE DATA
 
-  modelflux_resmatch = resamplemodel_final(datalam_match, modellam_shifted, modelflux_broadened)
+  modelflux_resmatch = resamplemodel_final(datalam_match, modellam_shifted, modelflux_broadened_vsini_ip)
   ; rename the wavelength array so we know we have matched the resolution to the data
   modellam_resmatch = datalam_match
 
@@ -327,12 +333,9 @@ pro savebestmodel_final, configfilepathandname
     /current, layout=[1,3,3], $
     /buffer)
   outputfigurefilename = outfilepath + 'figures/' + outfilename + '_bestfit_figure'
-
-  ; You can choose the file type for the output figures.
   ; p5.save, outputfigurefilename + '.png'
   p5.save, outputfigurefilename + '.pdf'
   ; p5.save, outputfigurefilename + '.eps'
-  
   p5.close
 
   ;;;;;;;


### PR DESCRIPTION
Added a feature to account for instrumental broadening profiles (IP) for the case analyzing spectra of slow rotators (i.e., spectral lines are so sharp that the instrumental profile is negligible).

The current (Dec 2024) default settings are optimized for the IPs of April-June 2018 Gemini South/IGRINS. Users will need to edit "get_sigma_ip.pro" if they are analyzing slow rotators' spectra from other instruments. (Ideally, it will be possible to adjust it from an external file, such as config files, in the future)